### PR TITLE
fix: カスタムチェックボックスにフォーカスインジケーターを追加

### DIFF
--- a/fe/app/globals.css
+++ b/fe/app/globals.css
@@ -148,6 +148,11 @@ body::before {
   flex-shrink: 0;
 }
 
+.todo-checkbox:focus-visible {
+  outline: 2px solid var(--accent-vermillion);
+  outline-offset: 2px;
+}
+
 .todo-checkbox:hover {
   border-color: var(--accent-vermillion-soft);
 }


### PR DESCRIPTION
## Summary
- `.todo-checkbox`に`:focus-visible`スタイルを追加し、キーボード操作時のフォーカスインジケーターを実装
- WCAG 2.4.7 フォーカスの可視化 (AA) に準拠

## Changes
- `fe/app/globals.css`: `.todo-checkbox:focus-visible`ルールを追加（`outline: 2px solid var(--accent-vermillion)`, `outline-offset: 2px`）

## Test plan
- [ ] キーボード（Tab）でチェックボックスにフォーカスし、朱色のアウトラインが表示されることを確認
- [ ] マウスクリック時にはフォーカスリングが表示されないことを確認（`:focus-visible`の挙動）
- [ ] チェック済み・未チェック両状態でフォーカスリングが正しく表示されることを確認
- [ ] `npm run build` が成功すること
- [ ] 既存テストが全て通ること

Closes #10

🤖 Generated with [Claude Code](https://claude.com/claude-code)