### PR TITLE
fix: ink-faintのコントラスト比をWCAG AA基準に適合 (#12)

### DIFF
--- a/fe/app/globals.css
+++ b/fe/app/globals.css
@@ -12,7 +12,7 @@
   --ink-dark: #2d2d2d;
   --ink-medium: #5c5c5c;
   --ink-light: #8a8a8a;
-  --ink-faint: #b8b0a4;
+  --ink-faint: #736b60;
 
   /* Accent — vermillion seal */
   --accent-vermillion: #c23b22;
@@ -60,7 +60,7 @@
     --ink-dark: #d4cfc4;
     --ink-medium: #a09888;
     --ink-light: #7a7268;
-    --ink-faint: #4a4540;
+    --ink-faint: #8b8279;
 
     --accent-vermillion: #e05a42;
     --accent-vermillion-soft: #c2493a;


### PR DESCRIPTION
## Summary
- CSS変数 `--ink-faint` のコントラスト比がWCAG 2.2 AA基準の4.5:1を大きく下回っていた問題を修正
- ライトモード: `#b8b0a4` → `#736b60` (1.89:1 → 4.63:1)
- ダークモード: `#4a4540` → `#8b8279` (1.83:1 → 4.60:1)

## WCAG達成基準
- **1.4.3 コントラスト (最低限) (AA)**: 4.5:1以上

## 影響箇所
`--ink-faint` を参照する全要素に適用:
- プレースホルダーテキスト ("What needs to be done?")
- チェックボックスの境界線
- テキスト入力の下線
- スクロールバー
- 各種UIテキスト・ボーダー

## Test plan
- [x] `npm run build` 成功
- [x] `npm test` 全テストパス (6/6)
- [x] ライトモードでプレースホルダーテキストの視認性を目視確認
- [x] ダークモードでプレースホルダーテキストの視認性を目視確認

Closes #12

🤖 Generated with [Claude Code](https://claude.com/claude-code)