### PR TITLE
fix: done-inkのコントラスト比をWCAG AA基準に適合させる

### DIFF
--- a/fe/app/globals.css
+++ b/fe/app/globals.css
@@ -20,7 +20,7 @@
 
   /* States */
   --done-wash: #e8e2d6;
-  --done-ink: #a09888;
+  --done-ink: #6e665c;
 
   /* Shadows */
   --shadow-ink: rgba(26, 26, 26, 0.08);
@@ -66,7 +66,7 @@
     --accent-vermillion-soft: #c2493a;
 
     --done-wash: #2a2720;
-    --done-ink: #6a6258;
+    --done-ink: #928879;
 
     --shadow-ink: rgba(0, 0, 0, 0.2);
     --shadow-ink-heavy: rgba(0, 0, 0, 0.35);


### PR DESCRIPTION
## Summary
- 完了済みTodoテキスト色 `--done-ink` のコントラスト比がWCAG AA基準(4.5:1)を満たしていなかった問題を修正
- ライトモード: `#a09888` → `#6e665c` (2.52:1 → 4.98:1)
- ダークモード: `#6a6258` → `#928879` (2.89:1 → 4.98:1)

## Test plan
- [x] `npm run typecheck` パス
- [x] `npm run lint` パス
- [x] `npm test` パス
- [ ] ライトモードで完了済みTodoのテキストが読みやすいことを目視確認
- [ ] ダークモードで完了済みTodoのテキストが読みやすいことを目視確認

Closes #13

🤖 Generated with [Claude Code](https://claude.com/claude-code)