### PR TITLE
fix: 残りアイテム数テキストのコントラスト比をWCAG AA基準に修正

### DIFF
--- a/fe/app/components/todo-footer.tsx
+++ b/fe/app/components/todo-footer.tsx
@@ -38,7 +38,7 @@ export function TodoFooter({
 
   return (
     <footer className="mt-8 flex items-center justify-between border-t border-ink-faint/20 pt-6">
-      <p className="text-sm text-ink-light tabular-nums">
+      <p className="text-sm text-ink-medium tabular-nums">
         <span className="font-medium text-ink-medium">{activeCount}</span>{" "}
         {activeCount === 1 ? "item" : "items"} remaining
       </p>


### PR DESCRIPTION
## Summary

- `todo-footer.tsx` の「X items remaining」テキストの色クラスを `text-ink-light` から `text-ink-medium` に変更
- コントラスト比を 3.04:1 → 約5.89:1 に改善し、WCAG AA 基準 (4.5:1) を満たすように修正

Closes #14

## Test plan

- [x] `npm run typecheck` — 型チェック通過
- [x] `npm test` — 全6テスト通過
- [x] `npm run lint` — Biome lint エラーなし

🤖 Generated with [Claude Code](https://claude.com/claude-code)