### PR TITLE
fix: 残りアイテム数にaria-liveを追加しスクリーンリーダーに変更を通知する (#16)

### DIFF
--- a/fe/app/components/todo-footer.tsx
+++ b/fe/app/components/todo-footer.tsx
@@ -38,7 +38,7 @@ export function TodoFooter({
 
   return (
     <footer className="mt-8 flex items-center justify-between border-t border-ink-faint/20 pt-6">
-      <p className="text-sm text-ink-medium tabular-nums">
+      <p role="status" aria-live="polite" className="text-sm text-ink-medium tabular-nums">
         <span className="font-medium text-ink-medium">{activeCount}</span>{" "}
         {activeCount === 1 ? "item" : "items"} remaining
       </p>


### PR DESCRIPTION
## Summary

- 残りアイテム数を表示する `<p>` 要素に `role="status"` と `aria-live="polite"` を追加
- Todo操作時にスクリーンリーダーが残数の変化を自動通知するようになる
- WCAG 4.1.3 ステータスメッセージ (AA) に準拠

## Test plan

- [ ] スクリーンリーダー (VoiceOver / NVDA) でTodo追加・削除・完了切り替え時に残りアイテム数の変更が読み上げられることを確認
- [ ] `role="status"` と `aria-live="polite"` が正しくレンダリングされていることをDevToolsで確認
- [ ] 既存テスト (`npm test`) が全て通過すること

Closes #16

🤖 Generated with [Claude Code](https://claude.ai/claude-code)