### PR TITLE
fix: スキップリンクを追加しWCAG 2.4.1に準拠する (#17)

### DIFF
--- a/fe/app/layout.tsx
+++ b/fe/app/layout.tsx
@@ -27,6 +27,12 @@ export default function RootLayout({
   return (
     <html lang="ja">
       <body className={`${dmSerif.variable} ${zenKaku.variable} antialiased`}>
+        <a
+          href="#main-content"
+          className="sr-only focus:not-sr-only focus:absolute focus:left-4 focus:top-4 focus:z-50 focus:rounded focus:bg-ink-black focus:px-4 focus:py-2 focus:text-washi-white focus:outline-none"
+        >
+          メインコンテンツへスキップ
+        </a>
         {children}
       </body>
     </html>

--- a/fe/app/page.tsx
+++ b/fe/app/page.tsx
@@ -91,7 +91,7 @@ export default function Home() {
           </div>
         </header>
 
-        <main>
+        <main id="main-content">
           <TodoInput onAdd={addTodo} />
 
           {loading ? (


### PR DESCRIPTION
## Summary
- `<body>` 直後に「メインコンテンツへスキップ」リンクを追加（通常は非表示、フォーカス時に表示）
- `<main>` 要素に `id="main-content"` を付与しスキップリンクのジャンプ先を設定
- WCAG 2.4.1（ブロックスキップ、レベルA）を達成

## Test plan
- [ ] Tabキーでページにフォーカスし、スキップリンクが表示されることを確認
- [ ] スキップリンクをEnterで押下し、メインコンテンツにフォーカスが移ることを確認
- [ ] スキップリンクがフォーカスを外すと非表示に戻ることを確認
- [ ] スクリーンリーダーでスキップリンクが読み上げられることを確認

Closes #17

🤖 Generated with [Claude Code](https://claude.com/claude-code)