### PR TITLE
fix: form要素にaria-labelを追加 (#18)

### DIFF
--- a/fe/app/components/todo-input.tsx
+++ b/fe/app/components/todo-input.tsx
@@ -20,7 +20,7 @@ export function TodoInput({ onAdd }: TodoInputProps) {
   };
 
   return (
-    <form onSubmit={handleSubmit} className="relative mb-12">
+    <form onSubmit={handleSubmit} aria-label="Add new todo" className="relative mb-12">
       <div className="flex items-end gap-4">
         <input
           ref={inputRef}


### PR DESCRIPTION
## Summary
- `<form>` 要素に `aria-label="Add new todo"` を追加し、スクリーンリーダーのランドマーク一覧でフォームの目的を識別可能にした

## Test plan
- [x] TypeScript型チェック通過
- [x] Vitest全テスト通過
- [ ] スクリーンリーダーでランドマーク一覧を表示し、フォームが「Add new todo」として認識されることを確認

Closes #18

🤖 Generated with [Claude Code](https://claude.com/claude-code)