### PR TITLE
fix: html lang属性をenに変更しUIテキストとの言語不一致を解消する

### DIFF
--- a/fe/app/components/todo-footer.tsx
+++ b/fe/app/components/todo-footer.tsx
@@ -38,10 +38,13 @@ export function TodoFooter({
 
   return (
     <footer className="mt-8 flex items-center justify-between border-t border-ink-faint/20 pt-6">
-      <p role="status" aria-live="polite" className="text-sm text-ink-medium tabular-nums">
+      <output
+        aria-live="polite"
+        className="text-sm text-ink-medium tabular-nums"
+      >
         <span className="font-medium text-ink-medium">{activeCount}</span>{" "}
         {activeCount === 1 ? "item" : "items"} remaining
-      </p>
+      </output>
 
       <nav className="flex gap-1" aria-label="Filter todos">
         {filters.map((f) => (

--- a/fe/app/components/todo-input.tsx
+++ b/fe/app/components/todo-input.tsx
@@ -20,7 +20,11 @@ export function TodoInput({ onAdd }: TodoInputProps) {
   };
 
   return (
-    <form onSubmit={handleSubmit} aria-label="Add new todo" className="relative mb-12">
+    <form
+      onSubmit={handleSubmit}
+      aria-label="Add new todo"
+      className="relative mb-12"
+    >
       <div className="flex items-end gap-4">
         <input
           ref={inputRef}

--- a/fe/app/layout.tsx
+++ b/fe/app/layout.tsx
@@ -25,13 +25,13 @@ export default function RootLayout({
   children: React.ReactNode;
 }>) {
   return (
-    <html lang="ja">
+    <html lang="en">
       <body className={`${dmSerif.variable} ${zenKaku.variable} antialiased`}>
         <a
           href="#main-content"
           className="sr-only focus:not-sr-only focus:absolute focus:left-4 focus:top-4 focus:z-50 focus:rounded focus:bg-ink-black focus:px-4 focus:py-2 focus:text-washi-white focus:outline-none"
         >
-          メインコンテンツへスキップ
+          <span lang="ja">メインコンテンツへスキップ</span>
         </a>
         {children}
       </body>


### PR DESCRIPTION
## Summary

- `<html lang="ja">` を `lang="en"` に変更（UIテキストが英語主体のため、WCAG 3.1.1 準拠）
- スキップリンクの日本語テキストに `<span lang="ja">` を付与（WCAG 3.1.2 準拠）
- `<p role="status">` を `<output>` 要素に置換（暗黙的に `role="status"` を持つセマンティック要素）
- Biomeフォーマット修正（既存のフォーマットエラー解消）

Closes #20

## Test plan

- [x] `npm test` — 全6テスト通過
- [x] `npm run lint` — エラー0件
- [x] `npm run typecheck` — 型チェック通過
- [ ] スクリーンリーダーで英語UIが正しく読み上げられることを確認
- [ ] スキップリンクが日本語音声エンジンで読み上げられることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)