### PR TITLE
fix: Todoリスト領域にsr-only見出しを追加しスクリーンリーダーの見出しナビゲーションを改善する (#21)

### DIFF
--- a/fe/app/page.tsx
+++ b/fe/app/page.tsx
@@ -94,6 +94,7 @@ export default function Home() {
         <main id="main-content">
           <TodoInput onAdd={addTodo} />
 
+          <h2 className="sr-only">Todo list</h2>
           {loading ? (
             <div className="flex justify-center py-20 animate-fade-in">
               <p className="text-ink-light text-sm tracking-wide">Loading...</p>


### PR DESCRIPTION
## Summary
- Todoリスト領域の前に `<h2 className="sr-only">Todo list</h2>` を追加
- スクリーンリーダーの見出しナビゲーション（Hキー）でTodoリストセクションへ素早くジャンプ可能に
- `sr-only` クラスにより視覚的な表示には影響なし

Closes #21

## Test plan
- [x] TypeScript型チェック通過
- [x] Biome lint通過
- [x] Vitest全6テスト通過
- [ ] スクリーンリーダー（VoiceOver/NVDA）でHキーによる見出しナビゲーションが機能することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)