### PR TITLE
fix: devcontainerのワークスペースパスを固定値に変更し環境依存を解消する

### DIFF
--- a/.devcontainer/compose.yaml
+++ b/.devcontainer/compose.yaml
@@ -7,7 +7,7 @@ services:
       dockerfile: .devcontainer/Dockerfile
 
     volumes:
-    - ../:/workspaces/${localWorkspaceFolderBasename}:cached
+    - ../:/workspaces/rails-nextjs-todo:cached
 
     # Overrides default command so things don't shut down after the process ends.
     command: sleep infinity

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -4,7 +4,7 @@
   "name": "rails-nextjs-todo",
   "dockerComposeFile": "compose.yaml",
   "service": "rails-app",
-  "workspaceFolder": "/workspaces/${localWorkspaceFolderBasename}",
+  "workspaceFolder": "/workspaces/rails-nextjs-todo",
   // Features to add to the dev container. More info: https://containers.dev/features.
   "features": {
     "ghcr.io/devcontainers/features/github-cli:1": {},


### PR DESCRIPTION
## Summary
- `.devcontainer/compose.yaml` と `.devcontainer/devcontainer.json` の `${localWorkspaceFolderBasename}` 変数を `rails-nextjs-todo` に置換
- 一部環境（Claude Code等）で変数が正しく展開されない問題を解消

## Test plan
- [x] devcontainerが正常にビルド・起動できることを確認
- [ ] ワークスペースフォルダが `/workspaces/rails-nextjs-todo` に正しくマウントされることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)