### PR TITLE
chore: デプロイ先をConoHa VPSからKAGOYA VPSに移行する

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -41,6 +41,6 @@
     }
   },
   "mounts": [
-    "source=${localEnv:HOME}/.ssh,target=/home/vscode/.ssh,type=bind,consistency=cached"
+    "source=${localEnv:HOME}/.ssh/kagoya,target=/home/vscode/.ssh/id_rsa,type=bind,consistency=cached"
   ]
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -80,7 +80,7 @@ npm run generate:types             # OpenAPIスキーマからTypeScript型を�
 - **環境変数**: `dotenv-rails` で `be/.env` を自動読み込み（development/test環境）
 - **OpenAPI**: rswagでrequest specからswagger.yaml を自動生成。Swagger UI は `/api-docs` で閲覧可能。swagger.yamlはgit管理
 - **CORS**: `rack-cors` gem で FE からのクロスオリジンリクエストを許可。許可オリジンは環境変数 `CORS_ORIGINS`（デフォルト: `http://localhost:3001`）。設定は `config/initializers/cors.rb`
-- **デプロイ**: Kamal → ConoHa VPS (Docker Hub レジストリ, Let's Encrypt SSL via Thruster)。設定は `config/deploy.yml`、シークレットは `.kamal/secrets`。ドメイン: `rails-nextjs-todo.api.tom-chiba.com`
+- **デプロイ**: Kamal → KAGOYA VPS (Docker Hub レジストリ, Let's Encrypt SSL via Thruster)。設定は `config/deploy.yml`、シークレットは `.kamal/secrets`。ドメイン: `rails-nextjs-todo.api.tom-chiba.com`
 - **OpenAPI (本番)**: rswag は development/test のみ。本番では `defined?` ガード付きでルーティングから除外される（`config/routes.rb` 参照）
 
 ## フロントエンド重要事項

--- a/be/config/deploy.yml
+++ b/be/config/deploy.yml
@@ -7,10 +7,10 @@ image: chibatomoki/be
 # Deploy to these servers.
 servers:
   web:
-    - 160.251.177.3
+    - 133.18.125.127
   # job:
   #   hosts:
-  #     - 160.251.177.3
+  #     - 133.18.125.127
   #   cmd: bin/jobs
 
 # Enable SSL auto certification via Let's Encrypt and allow for multiple apps on a single web server.


### PR DESCRIPTION
## Summary
- デプロイ先サーバーのIPアドレスをConoHa VPS (160.251.177.3) からKAGOYA VPS (133.18.125.127) に変更
- devcontainerのSSHマウントを `.ssh` ディレクトリ全体からKAGOYA専用鍵 (`~/.ssh/kagoya`) に限定
- CLAUDE.mdのVPSプロバイダ名をConoHaからKAGOYAに更新

## Test plan
- [ ] `bin/kamal deploy` でKAGOYA VPSへのデプロイが成功すること
- [ ] devcontainerの再ビルド後、SSH鍵が正しくマウントされること

🤖 Generated with [Claude Code](https://claude.com/claude-code)