### PR TITLE
refactor: シークレット保護をguardrailsからhookify + permissions.denyへ移行

### DIFF
--- a/.claude/hookify.block-bash-env-display.local.md
+++ b/.claude/hookify.block-bash-env-display.local.md
@@ -1,0 +1,22 @@
+---
+name: block-bash-env-display
+enabled: true
+event: bash
+action: block
+pattern: \bprintenv\b|(^|[\s;&|`(])env\s*$|(^|[\s;&|`(])env\s*\||(^|[\s;&|`(])set\s*$|echo\s+["']?\$[A-Za-z_]
+---
+
+🚫 **環境変数の表示コマンドをブロックしました**
+
+シェル経由で環境変数を出力することは許可されていません。
+
+**ブロックされたパターン:**
+- `printenv` / `printenv VAR` — 環境変数のダンプ
+- `env` 単独 / `env | grep ...` — 全環境変数の列挙
+- `set` 単独 — シェル変数を含む全変数の列挙
+- `echo $VAR` — 環境変数の値出力
+
+**意図がそうでない場合:**
+- `env FOO=bar cmd` のラッパー用途は別パターンとして検出されます（その場合も意図確認が必要）
+- ファイル名検索なら `find . -name '.env'` などへ書き換え
+- どうしても値の確認が必要な場合はユーザー自身に依頼

--- a/.claude/hookify.block-bash-env-set.local.md
+++ b/.claude/hookify.block-bash-env-set.local.md
@@ -1,0 +1,19 @@
+---
+name: block-bash-env-set
+enabled: true
+event: bash
+action: block
+pattern: \bexport\s+[A-Za-z_][A-Za-z0-9_]*\s*=|(^|[\s;&|`(])[A-Z_][A-Z0-9_]*=[^\s;&|`]+\s+[A-Za-z]
+---
+
+🚫 **環境変数の設定コマンドをブロックしました**
+
+シェル経由で環境変数をセットすることは許可されていません。
+
+**ブロックされたパターン:**
+- `export FOO=bar` — exportによる環境変数定義
+- `FOO=bar command ...` — コマンド単位の一時的な環境変数注入（`env FOO=bar cmd` 含む）
+
+**意図がそうでない場合:**
+- 一時的な環境変数が本当に必要なら、ユーザーに依頼するか `.env.example` テンプレ更新でカバー
+- `make BUILD=debug install` などビルド変数の受け渡しが必要な場合は、このルールを `action: warn` に変更するか、対象を絞ったパターンへ調整

--- a/.claude/hookify.block-secret-bash-read.local.md
+++ b/.claude/hookify.block-secret-bash-read.local.md
@@ -3,12 +3,12 @@ name: block-secret-bash-read
 enabled: true
 event: bash
 action: block
-pattern: (cat|head|tail|less|more|bat|vim|nano|vi|code|open|sed|awk|grep|rg|source|\.\s|strings|xxd|od|base64|python3?|node|ruby|perl|bash|sh)\s+.*(\.\benv\b|master\.key|credentials\.yml\.enc|\.kamal/secrets)
+pattern: (cat|head|tail|less|more|bat|vim|nano|vi|code|open|sed|awk|grep|rg|source|\.\s|strings|xxd|od|base64|python3?|node|ruby|perl|bash|sh|tee)\s+.*(\.\benv\b|master\.key|credentials\.yml\.enc|\.kamal/secrets)
 ---
 
-🚫 **Bashでのシークレットファイル読み取りをブロックしました**
+🚫 **Bashでのシークレットファイル読み書きをブロックしました**
 
-シークレットファイルをBashコマンドで読み取ることは許可されていません。
+シークレットファイルをBashコマンドで読み書きすることは許可されていません。
 
 **ブロックされたパターン:**
 - `cat .env`, `head master.key` などの読み取りコマンド
@@ -16,3 +16,4 @@ pattern: (cat|head|tail|less|more|bat|vim|nano|vi|code|open|sed|awk|grep|rg|sour
 - `source .env`, `. .env` などのシェル読み込み
 - `python3`, `node`, `ruby` などスクリプト言語経由のアクセス
 - `strings`, `xxd`, `od`, `base64` などバイナリ解析ツール
+- `echo X | tee .env` などの書き込み・追記

--- a/.claude/hookify.block-secret-read-tool.local.md
+++ b/.claude/hookify.block-secret-read-tool.local.md
@@ -1,7 +1,8 @@
 ---
-name: block-secret-file-read
+name: block-secret-read-tool
 enabled: true
-event: file
+event: all
+tool_matcher: Read
 action: block
 conditions:
   - field: file_path
@@ -9,13 +10,16 @@ conditions:
     pattern: (\.env$|\.env\.|master\.key|credentials\.yml\.enc|\.kamal/secrets)
 ---
 
-🚫 **シークレットファイルへのアクセスをブロックしました**
+🚫 **シークレットファイルへのRead経由アクセスをブロックしました**
 
-このファイルにはシークレット情報が含まれている可能性があります。
-読み取り・編集は許可されていません。
+Read ツールでシークレットファイルを開くことは許可されていません。
 
 **保護対象ファイル:**
 - `.env` / `.env.*`（`.env.example` 含む — テンプレ参照が必要なら本ルールを調整）
 - `config/master.key` — Rails マスターキー
 - `config/credentials.yml.enc` — 暗号化済み認証情報
 - `.kamal/secrets*` — デプロイ用シークレット
+
+**回避策:**
+- 必要なキー名のみをユーザーに確認する
+- 値の確認が必要な場合はユーザー自身に依頼する

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -26,20 +26,22 @@
       "Bash(npm run lint)",
       "Bash(npm run format)",
       "Bash(npm run typecheck)"
-    ]
-  },
-  "hooks": {
-    "PreToolUse": [
-      {
-        "matcher": "Write|Edit|MultiEdit",
-        "hooks": [
-          {
-            "type": "command",
-            "command": "/home/linuxbrew/.linuxbrew/bin/guardrails",
-            "timeout": 1000
-          }
-        ]
-      }
+    ],
+    "deny": [
+      "Read(**/.env*)",
+      "Edit(**/.env*)",
+      "Write(**/.env*)",
+      "Read(**/master.key)",
+      "Edit(**/master.key)",
+      "Write(**/master.key)",
+      "Read(**/credentials*.enc)",
+      "Edit(**/credentials*.enc)",
+      "Write(**/credentials*.enc)",
+      "Read(**/.kamal/secrets*)",
+      "Edit(**/.kamal/secrets*)",
+      "Write(**/.kamal/secrets*)",
+      "Bash(printenv*)",
+      "Bash(env*)"
     ]
   },
   "enabledPlugins": {
@@ -50,7 +52,6 @@
     "commit-commands@claude-plugins-official": true,
     "claude-md-management@claude-plugins-official": true,
     "claude-code-setup@claude-plugins-official": true,
-    "complete-workflow-system@thkt-development-workflows": true,
     "code-simplifier@claude-plugins-official": true,
     "a11y-specialist-skills@a11y-specialist-skills": true,
     "pr-review-toolkit@claude-plugins-official": true,

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -4,9 +4,6 @@ FROM ghcr.io/rails/devcontainer/images/ruby:$RUBY_VERSION
 
 RUN curl -fsSL https://claude.ai/install.sh | bash
 
-RUN /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
-RUN /home/linuxbrew/.linuxbrew/bin/brew install thkt/tap/guardrails
-
 # Ensure binding is always 0.0.0.0
 # Binds the server to all IP addresses of the container, so it can be accessed from outside the container.
 ENV BINDING="0.0.0.0"

--- a/README.md
+++ b/README.md
@@ -2,11 +2,10 @@
 
 1. `gh auth login` で `gh` コマンドを使えるように
 2. `claude` を実行して使える環境を Claude Code を使えるように
-3. Claude Code 内で `/plugin marketplace add thkt/claude-config`
-4. Claude Code 内で `/plugin marketplace add masuP9/a11y-specialist-skills`
-5. fe/.env.example をベースに fe/.env を作成
-6. fe/ 内で `npm i`
-7. be/ 内で `bundle install`
+3. Claude Code 内で `/plugin marketplace add masuP9/a11y-specialist-skills`
+4. fe/.env.example をベースに fe/.env を作成
+5. fe/ 内で `npm i`
+6. be/ 内で `bundle install`
 
 ## 本番デプロイ
 


### PR DESCRIPTION
## Summary
- thkt/guardrails Hook と Homebrew インストール処理を撤去し dev container のビルド時間を短縮
- シークレット保護を hookify ルール + `settings.json` の `permissions.deny` の二層構成に移行
- 環境変数の表示・設定操作と Read tool 経由のシークレットファイル参照もブロック対象に追加
- 既存 bash rule に `tee` を追加し書き込み経路もカバー、`.env.example` の例外を削除して挙動を統一

🤖 Generated with [Claude Code](https://claude.com/claude-code)
