### PR TITLE
feat: Todo に締切日を追加できるようにする (#8)

### DIFF
--- a/be/app/controllers/api/v1/todos_controller.rb
+++ b/be/app/controllers/api/v1/todos_controller.rb
@@ -45,7 +45,7 @@ module Api
       end
 
       def todo_params
-        params.expect(todo: [ :text, :completed ])
+        params.expect(todo: [ :text, :completed, :due_date ])
       end
     end
   end

--- a/be/db/migrate/20260527071231_add_due_date_to_todos.rb
+++ b/be/db/migrate/20260527071231_add_due_date_to_todos.rb
@@ -1,0 +1,5 @@
+class AddDueDateToTodos < ActiveRecord::Migration[8.1]
+  def change
+    add_column :todos, :due_date, :datetime, null: true
+  end
+end

--- a/be/db/schema.rb
+++ b/be/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_03_07_103924) do
+ActiveRecord::Schema[8.1].define(version: 2026_05_27_071231) do
   create_table "active_storage_attachments", force: :cascade do |t|
     t.bigint "blob_id", null: false
     t.datetime "created_at", null: false
@@ -51,6 +51,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_03_07_103924) do
   create_table "todos", force: :cascade do |t|
     t.boolean "completed", default: false, null: false
     t.datetime "created_at", null: false
+    t.datetime "due_date"
     t.string "text", null: false
     t.datetime "updated_at", null: false
     t.integer "user_id", null: false

--- a/be/db/seeds/02_todos.rb
+++ b/be/db/seeds/02_todos.rb
@@ -5,9 +5,9 @@ dev_user = User.find_by!(email_address: "dev@example.com")
 SEED_TODOS = [
   { text: "牛乳を買う", completed: false, image: "milk.png" },
   { text: "メールに返信する", completed: true },
-  { text: "レポートを書く", completed: false },
+  { text: "レポートを書く", completed: false, due_date: 3.days.from_now.change(hour: 18) },
   { text: "部屋を掃除する", completed: true },
-  { text: "ランニングをする", completed: false }
+  { text: "ランニングをする", completed: false, due_date: 2.days.ago.change(hour: 7) }
 ].freeze
 
 SEED_TODOS.each do |attrs|

--- a/be/spec/requests/api/v1/todos_swagger_spec.rb
+++ b/be/spec/requests/api/v1/todos_swagger_spec.rb
@@ -35,17 +35,20 @@ RSpec.describe "Api::V1::Todos", type: :request do
       produces "application/json"
       parameter name: :"todo[text]", in: :formData, type: :string, required: true, description: "Todoテキスト"
       parameter name: :"todo[completed]", in: :formData, type: :boolean, required: false, description: "完了フラグ"
+      parameter name: :"todo[due_date]", in: :formData, type: :string, format: "date-time", required: false, description: "締切日時 (ISO 8601)"
       parameter name: :image, in: :formData, type: :file, required: false, description: "画像ファイル (JPEG, PNG, GIF, WebP / 最大5MB)"
 
       response "201", "作成成功" do
         schema "$ref" => "#/components/schemas/Todo"
         let(:"todo[text]") { "New todo" }
+        let(:"todo[due_date]") { "2026-06-01T09:00:00Z" }
         let(:image) { nil }
 
         run_test! do |response|
           json = response.parsed_body
           expect(json["text"]).to eq("New todo")
           expect(json["completed"]).to be false
+          expect(json["due_date"]).to eq("2026-06-01T09:00:00.000Z")
           expect(json["image_url"]).to be_nil
         end
       end
@@ -109,10 +112,11 @@ RSpec.describe "Api::V1::Todos", type: :request do
         schema "$ref" => "#/components/schemas/Todo"
         let(:todo) { create(:todo, user: user) }
         let(:id) { todo.id }
-        let(:params) { { todo: { completed: true } } }
+        let(:params) { { todo: { completed: true, due_date: "2026-06-01T09:00:00Z" } } }
 
         run_test! do |response|
           expect(response.parsed_body["completed"]).to be true
+          expect(response.parsed_body["due_date"]).to eq("2026-06-01T09:00:00.000Z")
         end
       end
 

--- a/be/spec/swagger_helper.rb
+++ b/be/spec/swagger_helper.rb
@@ -22,11 +22,12 @@ RSpec.configure do |config|
               id: { type: :integer },
               text: { type: :string },
               completed: { type: :boolean },
+              due_date: { type: :string, format: "date-time", nullable: true },
               image_url: { type: :string, nullable: true },
               created_at: { type: :string, format: "date-time" },
               updated_at: { type: :string, format: "date-time" }
             },
-            required: %w[id text completed image_url created_at updated_at]
+            required: %w[id text completed due_date image_url created_at updated_at]
           },
           TodoInput: {
             type: :object,
@@ -35,7 +36,8 @@ RSpec.configure do |config|
                 type: :object,
                 properties: {
                   text: { type: :string },
-                  completed: { type: :boolean }
+                  completed: { type: :boolean },
+                  due_date: { type: :string, format: "date-time", nullable: true }
                 }
               }
             },

--- a/be/swagger/v1/swagger.yaml
+++ b/be/swagger/v1/swagger.yaml
@@ -312,6 +312,10 @@ components:
           type: string
         completed:
           type: boolean
+        due_date:
+          type: string
+          format: date-time
+          nullable: true
         image_url:
           type: string
           nullable: true
@@ -325,6 +329,7 @@ components:
       - id
       - text
       - completed
+      - due_date
       - image_url
       - created_at
       - updated_at
@@ -338,6 +343,10 @@ components:
               type: string
             completed:
               type: boolean
+            due_date:
+              type: string
+              format: date-time
+              nullable: true
       required:
       - todo
     AuthInput:

--- a/fe/app/components/todo-input.tsx
+++ b/fe/app/components/todo-input.tsx
@@ -1,9 +1,10 @@
 "use client";
 
 import { useEffect, useRef, useState } from "react";
+import { inputValueToIso } from "../lib/due-date";
 
 type TodoInputProps = {
-  onAdd: (text: string, image?: File) => void;
+  onAdd: (text: string, image?: File, dueDate?: string | null) => void;
 };
 
 const ACCEPTED_TYPES = "image/jpeg,image/png,image/gif,image/webp";
@@ -12,6 +13,7 @@ const MAX_SIZE = 5 * 1024 * 1024; // 5MB
 export function TodoInput({ onAdd }: TodoInputProps) {
   const inputRef = useRef<HTMLInputElement>(null);
   const fileRef = useRef<HTMLInputElement>(null);
+  const [dueDate, setDueDate] = useState("");
   const [preview, setPreview] = useState<string | null>(null);
   const [selectedFile, setSelectedFile] = useState<File | null>(null);
   const [error, setError] = useState<string | null>(null);
@@ -51,8 +53,9 @@ export function TodoInput({ onAdd }: TodoInputProps) {
     e.preventDefault();
     const text = inputRef.current?.value.trim();
     if (!text) return;
-    onAdd(text, selectedFile ?? undefined);
+    onAdd(text, selectedFile ?? undefined, inputValueToIso(dueDate));
     if (inputRef.current) inputRef.current.value = "";
+    setDueDate("");
     clearImage();
   };
 
@@ -132,6 +135,33 @@ export function TodoInput({ onAdd }: TodoInputProps) {
             />
           </svg>
         </button>
+      </div>
+
+      <div className="mt-3 flex items-center gap-2">
+        <label
+          htmlFor="new-todo-due-date"
+          className="text-xs tracking-wide text-ink-faint uppercase"
+        >
+          Due
+        </label>
+        <input
+          id="new-todo-due-date"
+          type="datetime-local"
+          value={dueDate}
+          onChange={(e) => setDueDate(e.target.value)}
+          className="ink-input text-sm text-ink-medium"
+          aria-label="Due date"
+        />
+        {dueDate && (
+          <button
+            type="button"
+            onClick={() => setDueDate("")}
+            className="text-xs text-ink-faint transition-colors hover:text-accent-vermillion"
+            aria-label="Clear due date"
+          >
+            Clear
+          </button>
+        )}
       </div>
 
       {error && (

--- a/fe/app/components/todo-item.tsx
+++ b/fe/app/components/todo-item.tsx
@@ -2,6 +2,12 @@
 
 import { AnimatePresence, motion } from "motion/react";
 import { useEffect, useRef, useState } from "react";
+import {
+  formatDueDate,
+  inputValueToIso,
+  isOverdue,
+  isoToInputValue,
+} from "../lib/due-date";
 import type { Todo } from "../types";
 import { ImageLightbox } from "./image-lightbox";
 
@@ -11,6 +17,7 @@ type TodoItemProps = {
   onDelete: (id: number) => void;
   onDeleteImage?: (id: number) => void;
   onEdit: (id: number, text: string) => void;
+  onEditDueDate: (id: number, dueDate: string | null) => void;
 };
 
 export function TodoItem({
@@ -19,6 +26,7 @@ export function TodoItem({
   onDelete,
   onDeleteImage,
   onEdit,
+  onEditDueDate,
 }: TodoItemProps) {
   const [isEditing, setIsEditing] = useState(false);
   const [editText, setEditText] = useState(todo.text);
@@ -29,6 +37,14 @@ export function TodoItem({
   const wasEditingRef = useRef(false);
   const [lightboxOpen, setLightboxOpen] = useState(false);
   const thumbnailButtonRef = useRef<HTMLButtonElement>(null);
+  const [isEditingDueDate, setIsEditingDueDate] = useState(false);
+  const [dueDateValue, setDueDateValue] = useState("");
+  const dueDateInputRef = useRef<HTMLInputElement>(null);
+  const overdue = isOverdue(todo.due_date, todo.completed);
+
+  useEffect(() => {
+    if (isEditingDueDate) dueDateInputRef.current?.focus();
+  }, [isEditingDueDate]);
 
   useEffect(() => {
     if (isEditing) {
@@ -84,6 +100,26 @@ export function TodoItem({
     skipBlurRef.current = false;
   };
 
+  const handleDueDateEditStart = () => {
+    setDueDateValue(isoToInputValue(todo.due_date));
+    setIsEditingDueDate(true);
+  };
+
+  const handleDueDateSave = () => {
+    onEditDueDate(todo.id, inputValueToIso(dueDateValue));
+    setIsEditingDueDate(false);
+  };
+
+  const handleDueDateClear = () => {
+    onEditDueDate(todo.id, null);
+    setIsEditingDueDate(false);
+  };
+
+  const handleDueDateSubmit = (e: React.SyntheticEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    handleDueDateSave();
+  };
+
   return (
     <motion.li
       layout
@@ -135,6 +171,97 @@ export function TodoItem({
             {todo.text}
           </span>
         )}
+        <div className="mt-1.5 flex items-center gap-2">
+          {isEditingDueDate ? (
+            <form
+              onSubmit={handleDueDateSubmit}
+              className="flex items-center gap-2"
+            >
+              <input
+                ref={dueDateInputRef}
+                type="datetime-local"
+                value={dueDateValue}
+                onChange={(e) => setDueDateValue(e.target.value)}
+                className="ink-input text-xs text-ink-medium"
+                aria-label={`Due date for "${todo.text}"`}
+              />
+              <button
+                type="submit"
+                className="text-xs text-ink-faint transition-colors hover:text-ink-medium"
+              >
+                Save
+              </button>
+              {todo.due_date && (
+                <button
+                  type="button"
+                  onClick={handleDueDateClear}
+                  className="text-xs text-ink-faint transition-colors hover:text-accent-vermillion"
+                >
+                  Clear
+                </button>
+              )}
+              <button
+                type="button"
+                onClick={() => setIsEditingDueDate(false)}
+                className="text-xs text-ink-faint transition-colors hover:text-ink-medium"
+              >
+                Cancel
+              </button>
+            </form>
+          ) : todo.due_date ? (
+            <button
+              type="button"
+              onClick={handleDueDateEditStart}
+              className={`inline-flex items-center gap-1 rounded text-xs transition-colors focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent-vermillion ${
+                overdue
+                  ? "text-accent-vermillion"
+                  : "text-ink-light hover:text-ink-medium"
+              }`}
+              aria-label={`Due ${formatDueDate(todo.due_date)}${overdue ? " (overdue)" : ""}. Edit due date.`}
+            >
+              <svg
+                width="12"
+                height="12"
+                viewBox="0 0 16 16"
+                fill="none"
+                aria-hidden="true"
+              >
+                <rect
+                  x="2"
+                  y="3"
+                  width="12"
+                  height="11"
+                  rx="1.5"
+                  stroke="currentColor"
+                  strokeWidth="1.5"
+                />
+                <path
+                  d="M2 6h12M5.5 1.5v3M10.5 1.5v3"
+                  stroke="currentColor"
+                  strokeWidth="1.5"
+                  strokeLinecap="round"
+                />
+              </svg>
+              <span>{formatDueDate(todo.due_date)}</span>
+              {overdue && (
+                <span className="font-medium tracking-wide uppercase">
+                  Overdue
+                </span>
+              )}
+            </button>
+          ) : (
+            !isEditing && (
+              <button
+                type="button"
+                onClick={handleDueDateEditStart}
+                className="text-xs text-ink-faint opacity-0 transition-all hover:text-ink-medium group-hover:opacity-100 focus:opacity-100"
+                aria-label={`Set due date for "${todo.text}"`}
+              >
+                Set due date
+              </button>
+            )
+          )}
+        </div>
         {todo.image_url && (
           <div className="mt-2 flex items-end gap-2">
             <button

--- a/fe/app/components/todo-list.tsx
+++ b/fe/app/components/todo-list.tsx
@@ -10,6 +10,7 @@ type TodoListProps = {
   onDelete: (id: number) => void;
   onDeleteImage?: (id: number) => void;
   onEdit: (id: number, text: string) => void;
+  onEditDueDate: (id: number, dueDate: string | null) => void;
 };
 
 export function TodoList({
@@ -18,6 +19,7 @@ export function TodoList({
   onDelete,
   onDeleteImage,
   onEdit,
+  onEditDueDate,
 }: TodoListProps) {
   if (todos.length === 0) {
     return <EmptyState />;
@@ -34,6 +36,7 @@ export function TodoList({
             onDelete={onDelete}
             onDeleteImage={onDeleteImage}
             onEdit={onEdit}
+            onEditDueDate={onEditDueDate}
           />
         ))}
       </AnimatePresence>

--- a/fe/app/generated/models/todo.ts
+++ b/fe/app/generated/models/todo.ts
@@ -10,6 +10,8 @@ export interface Todo {
   text: string;
   completed: boolean;
   /** @nullable */
+  due_date: string | null;
+  /** @nullable */
   image_url: string | null;
   created_at: string;
   updated_at: string;

--- a/fe/app/generated/models/todoInputTodo.ts
+++ b/fe/app/generated/models/todoInputTodo.ts
@@ -8,4 +8,6 @@
 export type TodoInputTodo = {
   text?: string;
   completed?: boolean;
+  /** @nullable */
+  due_date?: string | null;
 };

--- a/fe/app/hooks/use-todos-mutation.test.ts
+++ b/fe/app/hooks/use-todos-mutation.test.ts
@@ -17,6 +17,7 @@ function makeTodo(overrides: Partial<Todo> = {}): Todo {
     id: 1,
     text: "Test todo",
     completed: false,
+    due_date: null,
     image_url: null,
     created_at: "2026-01-01T00:00:00Z",
     updated_at: "2026-01-01T00:00:00Z",

--- a/fe/app/lib/due-date.ts
+++ b/fe/app/lib/due-date.ts
@@ -1,0 +1,41 @@
+// 締切日 (ISO 8601 文字列) と datetime-local 入力値・表示文字列の相互変換ユーティリティ
+
+/** ISO 文字列を <input type="datetime-local"> 用の "YYYY-MM-DDTHH:mm" (ローカル時刻) に変換 */
+export function isoToInputValue(iso: string | null): string {
+  if (!iso) return "";
+  const date = new Date(iso);
+  if (Number.isNaN(date.getTime())) return "";
+  const pad = (n: number) => String(n).padStart(2, "0");
+  return `${date.getFullYear()}-${pad(date.getMonth() + 1)}-${pad(date.getDate())}T${pad(date.getHours())}:${pad(date.getMinutes())}`;
+}
+
+/** datetime-local の入力値を ISO 文字列に変換。空なら null */
+export function inputValueToIso(value: string): string | null {
+  if (!value) return null;
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return null;
+  return date.toISOString();
+}
+
+const formatter = new Intl.DateTimeFormat(undefined, {
+  year: "numeric",
+  month: "short",
+  day: "numeric",
+  hour: "2-digit",
+  minute: "2-digit",
+});
+
+/** 締切日を人間向け表示文字列に整形 */
+export function formatDueDate(iso: string): string {
+  const date = new Date(iso);
+  if (Number.isNaN(date.getTime())) return "";
+  return formatter.format(date);
+}
+
+/** 未完了かつ締切日時を過ぎていれば true */
+export function isOverdue(iso: string | null, completed: boolean): boolean {
+  if (!iso || completed) return false;
+  const date = new Date(iso);
+  if (Number.isNaN(date.getTime())) return false;
+  return date.getTime() < Date.now();
+}

--- a/fe/app/page.test.tsx
+++ b/fe/app/page.test.tsx
@@ -86,6 +86,7 @@ beforeEach(() => {
         id: nextId++,
         text: input["todo[text]"],
         completed: false,
+        due_date: null,
         image_url: input.image ? "http://example.com/test.jpg" : null,
         created_at: new Date().toISOString(),
         updated_at: new Date().toISOString(),

--- a/fe/app/page.tsx
+++ b/fe/app/page.tsx
@@ -45,16 +45,22 @@ export default function Home() {
   });
 
   const addMutation = useTodosMutation({
-    mutationFn: (args: { text: string; image?: File }) =>
+    mutationFn: (args: {
+      text: string;
+      image?: File;
+      dueDate?: string | null;
+    }) =>
       postApiV1Todos({
         "todo[text]": args.text,
         ...(args.image ? { image: args.image } : {}),
+        ...(args.dueDate ? { "todo[due_date]": args.dueDate } : {}),
       }),
     updater: (args, todos) => [
       {
         id: -Date.now(),
         text: args.text,
         completed: false,
+        due_date: args.dueDate ?? null,
         image_url: null,
         created_at: new Date().toISOString(),
         updated_at: new Date().toISOString(),
@@ -93,13 +99,21 @@ export default function Home() {
       todos.map((t) => (t.id === id ? { ...t, text } : t)),
   });
 
+  const editDueDateMutation = useTodosMutation({
+    mutationFn: ({ id, dueDate }: { id: number; dueDate: string | null }) =>
+      patchApiV1TodosId(id, { todo: { due_date: dueDate } }),
+    updater: ({ id, dueDate }, todos) =>
+      todos.map((t) => (t.id === id ? { ...t, due_date: dueDate } : t)),
+  });
+
   const mutationError =
     addMutation.isError ||
     toggleMutation.isError ||
     deleteMutation.isError ||
     clearCompletedMutation.isError ||
     deleteImageMutation.isError ||
-    editMutation.isError;
+    editMutation.isError ||
+    editDueDateMutation.isError;
 
   // rerender-derived-state-no-effect: レンダー中に導出
   const filteredTodos =
@@ -160,7 +174,9 @@ export default function Home() {
 
         <main id="main-content">
           <TodoInput
-            onAdd={(text, image) => addMutation.mutate({ text, image })}
+            onAdd={(text, image, dueDate) =>
+              addMutation.mutate({ text, image, dueDate })
+            }
           />
 
           {mutationError && (
@@ -198,6 +214,9 @@ export default function Home() {
                 onDelete={(id) => deleteMutation.mutate(id)}
                 onDeleteImage={(id) => deleteImageMutation.mutate(id)}
                 onEdit={(id, text) => editMutation.mutate({ id, text })}
+                onEditDueDate={(id, dueDate) =>
+                  editDueDateMutation.mutate({ id, dueDate })
+                }
               />
               <TodoFooter
                 todos={todos}


### PR DESCRIPTION
## 概要

Issue #8 対応。Todo に締切日時を設定・表示・編集できるようにする。

データ型は **datetime**、UI スコープは **作成・表示・編集 + 期限切れ強調** で実装。

## 変更内容

### BE
- `todos` に `due_date` (datetime, null許可) カラムを追加
- `todo_params` で `due_date` を許可（`due_date` はカラムのため `as_json` で自動的にレスポンスへ含まれる）
- swagger スキーマ (`Todo` / `TodoInput`) と spec を更新し `swagger.yaml` を `rswag:specs:swaggerize` で再生成
- seeds に締切日サンプルを追加（期限切れ確認用を含む）

### FE
- `npm run generate:api` で API 型・hooks を再生成
- `lib/due-date.ts`（新規）: ISO ⇄ `datetime-local` 入力値 ⇄ 表示文字列の変換、期限切れ判定
- 作成フォームに `datetime-local` の締切日入力欄を追加
- 一覧での締切日表示・インライン編集（Save/Clear/Cancel）・期限切れ強調（朱色 + "Overdue"）

## テスト
- BE: 133 examples パス
- FE: typecheck / lint (biome) / 44 tests パス

Closes #8

🤖 Generated with [Claude Code](https://claude.com/claude-code)